### PR TITLE
Comments

### DIFF
--- a/app/api/comentarios/[id]/reportes/route.ts
+++ b/app/api/comentarios/[id]/reportes/route.ts
@@ -1,0 +1,169 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/drizzle/connection';
+import { reportesComentarios, comentarios } from '@/drizzle/schema';
+import { auth } from '@/lib/auth';
+import { headers } from 'next/headers';
+import { z } from 'zod';
+import { eq, and } from 'drizzle-orm';
+import { sendReportCommentThankYouEmail } from '@/lib/email';
+
+interface RouteParams {
+  params: Promise<{ id: string }>
+}
+
+const createReportSchema = z.object({
+  motivos: z.array(z.enum(['spam', 'contenido_inapropiado', 'informacion_falsa', 'otro']))
+    .min(1, 'Debe seleccionar al menos un motivo'),
+  observaciones: z.string()
+    .max(288, 'Las observaciones no pueden exceder 288 caracteres')
+    .optional(),
+});
+
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    });
+
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: 'No autorizado' },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+    const validatedData = createReportSchema.parse(body);
+    const { id: comentarioId } = await params;
+
+    // Verificar que el comentario existe y obtener información de la estación
+    const comentario = await db.query.comentarios.findFirst({
+      where: eq(comentarios.id, comentarioId),
+      with: {
+        estacion: {
+          columns: {
+            id: true,
+            nombre: true,
+          },
+        },
+      },
+    });
+
+    if (!comentario) {
+      return NextResponse.json(
+        { error: 'Comentario no encontrado' },
+        { status: 404 }
+      );
+    }
+
+    // Verificar que el usuario no está intentando reportar su propio comentario
+    if (comentario.usuarioId === session.user.id) {
+      return NextResponse.json(
+        { error: 'No puedes reportar tu propio comentario' },
+        { status: 400 }
+      );
+    }
+
+    // Verificar si el usuario ya reportó este comentario
+    const existingReport = await db.query.reportesComentarios.findFirst({
+      where: and(
+        eq(reportesComentarios.comentarioId, comentarioId),
+        eq(reportesComentarios.usuarioId, session.user.id)
+      ),
+    });
+
+    if (existingReport) {
+      return NextResponse.json(
+        { error: 'Ya has reportado este comentario anteriormente' },
+        { status: 409 }
+      );
+    }
+
+    // Crear reportes para cada motivo seleccionado
+    const reportes = await Promise.all(
+      validatedData.motivos.map(motivo =>
+        db.insert(reportesComentarios)
+          .values({
+            comentarioId,
+            usuarioId: session.user.id,
+            motivo,
+            observaciones: validatedData.observaciones?.trim() || null,
+          })
+          .returning()
+      )
+    );
+
+    // Enviar email de confirmación al usuario que reportó
+    try {
+      await sendReportCommentThankYouEmail({
+        user: {
+          id: session.user.id,
+          email: session.user.email!,
+          name: session.user.name || 'Usuario',
+        },
+        reason: validatedData.motivos.join(', '),
+        observation: validatedData.observaciones?.trim() || 'Sin observaciones adicionales',
+        stationName: comentario.estacion?.nombre || 'Estación desconocida',
+        stationId: comentario.estacionId,
+      });
+    } catch (emailError) {
+      // Log error but don't fail the request if email fails
+      console.error('Failed to send report confirmation email:', emailError);
+    }
+
+    return NextResponse.json({
+      message: 'Reporte enviado correctamente',
+      reportes: reportes.map(r => r[0])
+    }, { status: 201 });
+  } catch (error) {
+    console.error('Error al crear reporte:', error);
+    
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Datos inválidos', details: error.errors },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: 'Error interno del servidor' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    });
+
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: 'No autorizado' },
+        { status: 401 }
+      );
+    }
+
+    const { id: comentarioId } = await params;
+
+    // Solo permitir a los usuarios ver si ellos mismos han reportado
+    const userReports = await db.query.reportesComentarios.findMany({
+      where: and(
+        eq(reportesComentarios.comentarioId, comentarioId),
+        eq(reportesComentarios.usuarioId, session.user.id)
+      ),
+    });
+
+    return NextResponse.json({
+      hasReported: userReports.length > 0,
+      reportCount: userReports.length
+    });
+  } catch (error) {
+    console.error('Error al obtener reportes:', error);
+    return NextResponse.json(
+      { error: 'Error interno del servidor' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/comentarios/[id]/route.ts
+++ b/app/api/comentarios/[id]/route.ts
@@ -7,7 +7,10 @@ import { z } from 'zod';
 import { eq, and } from 'drizzle-orm';
 
 const updateComentarioSchema = z.object({
-  comentario: z.string().min(1, 'Comentario requerido').max(500, 'Comentario demasiado largo (máximo 500 caracteres)'),
+  comentario: z
+    .string()
+    .min(1, 'Comentario requerido')
+    .max(144, 'Comentario demasiado largo (máximo 144 caracteres)'),
 });
 
 export async function PUT(

--- a/app/api/comentarios/[id]/route.ts
+++ b/app/api/comentarios/[id]/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/drizzle/connection';
+import { comentarios } from '@/drizzle/schema';
+import { auth } from '@/lib/auth';
+import { headers } from 'next/headers';
+import { z } from 'zod';
+import { eq, and } from 'drizzle-orm';
+
+const updateComentarioSchema = z.object({
+  comentario: z.string().min(1, 'Comentario requerido').max(500, 'Comentario demasiado largo (máximo 500 caracteres)'),
+});
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    });
+
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: 'No autorizado' },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+    const validatedData = updateComentarioSchema.parse(body);
+
+    // Verificar que el comentario existe y pertenece al usuario
+    const existingComment = await db.query.comentarios.findFirst({
+      where: and(
+        eq(comentarios.id, id),
+        eq(comentarios.usuarioId, session.user.id)
+      ),
+    });
+
+    if (!existingComment) {
+      return NextResponse.json(
+        { error: 'Comentario no encontrado o no autorizado' },
+        { status: 404 }
+      );
+    }
+
+    // Actualizar el comentario
+    const updatedComentario = await db.update(comentarios)
+      .set({
+        comentario: validatedData.comentario,
+        fechaActualizacion: new Date(),
+      })
+      .where(eq(comentarios.id, id))
+      .returning();
+
+    return NextResponse.json(updatedComentario[0]);
+  } catch (error) {
+    console.error('Error al actualizar comentario:', error);
+    
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Datos inválidos', details: error.errors },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: 'Error interno del servidor' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    });
+
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: 'No autorizado' },
+        { status: 401 }
+      );
+    }
+
+    // Verificar que el comentario existe y pertenece al usuario
+    const existingComment = await db.query.comentarios.findFirst({
+      where: and(
+        eq(comentarios.id, id),
+        eq(comentarios.usuarioId, session.user.id)
+      ),
+    });
+
+    if (!existingComment) {
+      return NextResponse.json(
+        { error: 'Comentario no encontrado o no autorizado' },
+        { status: 404 }
+      );
+    }
+
+    // Eliminar el comentario
+    await db.delete(comentarios)
+      .where(eq(comentarios.id, id));
+
+    return NextResponse.json({ message: 'Comentario eliminado correctamente' });
+  } catch (error) {
+    console.error('Error al eliminar comentario:', error);
+    return NextResponse.json(
+      { error: 'Error interno del servidor' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/comentarios/[id]/votos/route.ts
+++ b/app/api/comentarios/[id]/votos/route.ts
@@ -1,0 +1,137 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/drizzle/connection';
+import { votosComentarios, comentarios } from '@/drizzle/schema';
+import { auth } from '@/lib/auth';
+import { headers } from 'next/headers';
+import { eq, and, count } from 'drizzle-orm';
+
+interface RouteParams {
+  params: Promise<{ id: string }>
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    });
+
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: 'No autorizado' },
+        { status: 401 }
+      );
+    }
+
+    const { id: comentarioId } = await params;
+
+    // Verificar que el comentario existe
+    const comentario = await db.query.comentarios.findFirst({
+      where: eq(comentarios.id, comentarioId),
+    });
+
+    if (!comentario) {
+      return NextResponse.json(
+        { error: 'Comentario no encontrado' },
+        { status: 404 }
+      );
+    }
+
+    // Verificar que el usuario no está intentando votar su propio comentario
+    if (comentario.usuarioId === session.user.id) {
+      return NextResponse.json(
+        { error: 'No puedes votar tu propio comentario' },
+        { status: 400 }
+      );
+    }
+
+    // Verificar si el usuario ya votó este comentario
+    const existingVote = await db.query.votosComentarios.findFirst({
+      where: and(
+        eq(votosComentarios.comentarioId, comentarioId),
+        eq(votosComentarios.usuarioId, session.user.id)
+      ),
+    });
+
+    if (existingVote) {
+      // Si ya votó, remover el voto (toggle)
+      await db.delete(votosComentarios)
+        .where(eq(votosComentarios.id, existingVote.id));
+      
+      // Obtener el nuevo conteo
+      const voteCount = await db
+        .select({ count: count() })
+        .from(votosComentarios)
+        .where(eq(votosComentarios.comentarioId, comentarioId));
+
+      return NextResponse.json({
+        voted: false,
+        voteCount: voteCount[0].count,
+        message: 'Voto removido'
+      });
+    } else {
+      // Si no votó, agregar el voto
+      await db.insert(votosComentarios)
+        .values({
+          comentarioId,
+          usuarioId: session.user.id,
+        });
+
+      // Obtener el nuevo conteo
+      const voteCount = await db
+        .select({ count: count() })
+        .from(votosComentarios)
+        .where(eq(votosComentarios.comentarioId, comentarioId));
+
+      return NextResponse.json({
+        voted: true,
+        voteCount: voteCount[0].count,
+        message: 'Voto agregado'
+      });
+    }
+  } catch (error) {
+    console.error('Error al procesar voto:', error);
+    return NextResponse.json(
+      { error: 'Error interno del servidor' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id: comentarioId } = await params;
+    
+    // Obtener el conteo de votos
+    const voteCount = await db
+      .select({ count: count() })
+      .from(votosComentarios)
+      .where(eq(votosComentarios.comentarioId, comentarioId));
+
+    // Verificar si el usuario actual ya votó (si está autenticado)
+    let userVoted = false;
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    });
+
+    if (session?.user) {
+      const existingVote = await db.query.votosComentarios.findFirst({
+        where: and(
+          eq(votosComentarios.comentarioId, comentarioId),
+          eq(votosComentarios.usuarioId, session.user.id)
+        ),
+      });
+      userVoted = !!existingVote;
+    }
+
+    return NextResponse.json({
+      voteCount: voteCount[0].count,
+      voted: userVoted
+    });
+  } catch (error) {
+    console.error('Error al obtener votos:', error);
+    return NextResponse.json(
+      { error: 'Error interno del servidor' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/comentarios/route.ts
+++ b/app/api/comentarios/route.ts
@@ -8,7 +8,10 @@ import { eq, and, desc } from 'drizzle-orm';
 
 const createComentarioSchema = z.object({
   estacionId: z.string().min(1, 'ID de estación requerido'),
-  comentario: z.string().min(1, 'Comentario requerido').max(500, 'Comentario demasiado largo (máximo 500 caracteres)'),
+  comentario: z
+    .string()
+    .min(1, 'Comentario requerido')
+    .max(144, 'Comentario demasiado largo (máximo 144 caracteres)'),
 });
 
 export async function POST(request: Request) {

--- a/app/api/comentarios/route.ts
+++ b/app/api/comentarios/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/drizzle/connection';
+import { comentarios } from '@/drizzle/schema';
+import { auth } from '@/lib/auth';
+import { headers } from 'next/headers';
+import { z } from 'zod';
+import { eq, and, desc } from 'drizzle-orm';
+
+const createComentarioSchema = z.object({
+  estacionId: z.string().min(1, 'ID de estación requerido'),
+  comentario: z.string().min(1, 'Comentario requerido').max(500, 'Comentario demasiado largo (máximo 500 caracteres)'),
+});
+
+export async function POST(request: Request) {
+  try {
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    });
+
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: 'No autorizado' },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+    const validatedData = createComentarioSchema.parse(body);
+
+    // Verificar si ya existe un comentario de este usuario para esta estación
+    const existingComment = await db.query.comentarios.findFirst({
+      where: and(
+        eq(comentarios.usuarioId, session.user.id),
+        eq(comentarios.estacionId, validatedData.estacionId)
+      ),
+    });
+
+    if (existingComment) {
+      return NextResponse.json(
+        { error: 'Ya tienes un comentario en esta estación. Puedes editarlo en su lugar.' },
+        { status: 409 }
+      );
+    }
+
+    // Crear el nuevo comentario
+    const nuevoComentario = await db.insert(comentarios)
+      .values({
+        usuarioId: session.user.id,
+        estacionId: validatedData.estacionId,
+        comentario: validatedData.comentario,
+      })
+      .returning();
+
+    return NextResponse.json(nuevoComentario[0], { status: 201 });
+  } catch (error) {
+    console.error('Error al crear comentario:', error);
+    
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Datos inválidos', details: error.errors },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: 'Error interno del servidor' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const estacionId = searchParams.get('estacionId');
+
+    if (!estacionId) {
+      return NextResponse.json(
+        { error: 'ID de estación requerido' },
+        { status: 400 }
+      );
+    }
+
+    // Obtener comentarios de la estación con información del usuario
+    const comentariosEstacion = await db.query.comentarios.findMany({
+      where: eq(comentarios.estacionId, estacionId),
+      with: {
+        usuario: {
+          columns: {
+            id: true,
+            name: true,
+            image: true,
+          },
+        },
+      },
+      orderBy: [desc(comentarios.fechaCreacion)],
+    });
+
+    return NextResponse.json(comentariosEstacion);
+  } catch (error) {
+    console.error('Error al obtener comentarios:', error);
+    return NextResponse.json(
+      { error: 'Error interno del servidor' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/estaciones/[id]/comentarios-count/route.ts
+++ b/app/api/estaciones/[id]/comentarios-count/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { db } from '@/drizzle/connection'
+import { comentarios } from '@/drizzle/schema'
+import { eq, count } from 'drizzle-orm'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+
+    if (!id) {
+      return NextResponse.json(
+        { error: 'ID de estación requerido' },
+        { status: 400 }
+      )
+    }
+
+    // Get comment count for this station
+    const result = await db
+      .select({
+        count: count(comentarios.id)
+      })
+      .from(comentarios)
+      .where(eq(comentarios.estacionId, id))
+
+    const commentCount = result[0]?.count || 0
+
+    return NextResponse.json({ count: commentCount })
+  } catch (error) {
+    console.error('Error al obtener conteo de comentarios:', error)
+    return NextResponse.json(
+      { error: 'Error interno del servidor' },
+      { status: 500 }
+    )
+  }
+}

--- a/components/StationDetailClient.tsx
+++ b/components/StationDetailClient.tsx
@@ -13,6 +13,7 @@ import { UserAvatar } from '@/components/ui/UserAvatar'
 import { authClient } from '@/lib/authClient'
 import { toast } from 'sonner'
 import { getCompanyLogoPath } from '@/lib/companyLogos'
+import { StationComments } from '@/components/station/StationComments'
 
 export interface StationPrice {
   id: string
@@ -703,6 +704,9 @@ export function StationDetailClient({ station }: StationDetailClientProps) {
                 )}
               </Card>
             )}
+
+            {/* Comments Section */}
+            <StationComments estacionId={station.id} />
 
             {/* Price History */}
             {/* <PriceHistory 

--- a/components/StationDetailClient.tsx
+++ b/components/StationDetailClient.tsx
@@ -705,9 +705,6 @@ export function StationDetailClient({ station }: StationDetailClientProps) {
               </Card>
             )}
 
-            {/* Comments Section */}
-            <StationComments estacionId={station.id} />
-
             {/* Price History */}
             {/* <PriceHistory 
               stationId={station.id}
@@ -720,6 +717,8 @@ export function StationDetailClient({ station }: StationDetailClientProps) {
           {/* Sidebar */}
           <div className="space-y-6">
             <StationDetail station={station} />
+            {/* Comments Section */}
+            <StationComments estacionId={station.id} />
           </div>
         </div>
       </main>

--- a/components/station/CommentActions.tsx
+++ b/components/station/CommentActions.tsx
@@ -1,0 +1,162 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { ThumbsUp, Flag, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { authClient } from '@/lib/authClient'
+import { ReportCommentModal } from './ReportCommentModal'
+
+interface CommentActionsProps {
+  comentarioId: string
+  voteCount: number
+  userVoted: boolean
+  userReported: boolean
+  isOwnComment: boolean
+  onVoteChange: (newVoteCount: number, userVoted: boolean) => void
+}
+
+export function CommentActions({ 
+  comentarioId, 
+  voteCount, 
+  userVoted, 
+  userReported,
+  isOwnComment,
+  onVoteChange 
+}: CommentActionsProps) {
+  const [isVoting, setIsVoting] = useState(false)
+  const [showReportModal, setShowReportModal] = useState(false)
+  const { data: session } = authClient.useSession()
+
+  const handleVote = async () => {
+    if (!session?.user) {
+      toast.error('Debes iniciar sesión para votar')
+      // Redirect to login with return URL
+      window.location.href = `/login?returnTo=${encodeURIComponent(window.location.pathname)}`
+      return
+    }
+
+    if (isOwnComment) {
+      toast.error('No puedes votar tu propio comentario')
+      return
+    }
+
+    try {
+      setIsVoting(true)
+      
+      const response = await fetch(`/api/comentarios/${comentarioId}/votos`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(error.error || 'Error al procesar voto')
+      }
+
+      const data = await response.json()
+      onVoteChange(data.voteCount, data.voted)
+      
+      // Show toast with appropriate message
+      if (data.voted) {
+        toast.success('¡Voto agregado!')
+      } else {
+        toast.success('Voto removido')
+      }
+    } catch (error) {
+      console.error('Error voting:', error)
+      toast.error(error instanceof Error ? error.message : 'Error al votar')
+    } finally {
+      setIsVoting(false)
+    }
+  }
+
+  const handleReport = () => {
+    if (!session?.user) {
+      toast.error('Debes iniciar sesión para reportar')
+      // Redirect to login with return URL
+      window.location.href = `/login?returnTo=${encodeURIComponent(window.location.pathname)}`
+      return
+    }
+
+    if (isOwnComment) {
+      toast.error('No puedes reportar tu propio comentario')
+      return
+    }
+
+    if (userReported) {
+      toast.info('Ya has reportado este comentario anteriormente')
+      return
+    }
+
+    setShowReportModal(true)
+  }
+
+  const handleReportSuccess = () => {
+    toast.success('Reporte enviado correctamente')
+    setShowReportModal(false)
+    // You might want to call a callback here to update the parent component
+  }
+
+  return (
+    <div className="flex items-center gap-2 mt-2">
+      {/* Vote Button - Only show if not own comment */}
+      {!isOwnComment && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleVote}
+          disabled={isVoting}
+          className={`h-8 px-2 text-xs transition-colors ${
+            userVoted 
+              ? 'text-blue-600 bg-blue-50 hover:bg-blue-100' 
+              : 'text-muted-foreground hover:text-blue-600'
+          }`}
+        >
+          {isVoting ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <ThumbsUp className={`h-3 w-3 mr-1 ${userVoted ? 'fill-current' : ''}`} />
+          )}
+          Es útil {voteCount > 0 && <span className="ml-1">{voteCount}</span>}
+        </Button>
+      )}
+      
+      {/* Vote count display for own comments */}
+      {isOwnComment && voteCount > 0 && (
+        <div className="h-8 px-2 text-xs text-muted-foreground flex items-center">
+          <ThumbsUp className="h-3 w-3 mr-1" />
+          {voteCount} {voteCount === 1 ? 'voto' : 'votos'}
+        </div>
+      )}
+
+      {/* Report Button - Only show if not own comment */}
+      {!isOwnComment && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleReport}
+          disabled={userReported}
+          className={`h-8 px-2 text-xs transition-colors ${
+            userReported
+              ? 'text-red-400 cursor-not-allowed'
+              : 'text-muted-foreground hover:text-red-600'
+          }`}
+        >
+          <Flag className="h-3 w-3 mr-1" />
+          {userReported ? 'Reportado' : 'Denunciar'}
+        </Button>
+      )}
+
+      {/* Report Modal */}
+      <ReportCommentModal
+        isOpen={showReportModal}
+        onClose={() => setShowReportModal(false)}
+        comentarioId={comentarioId}
+        onSuccess={handleReportSuccess}
+      />
+    </div>
+  )
+}

--- a/components/station/ReportCommentModal.tsx
+++ b/components/station/ReportCommentModal.tsx
@@ -1,0 +1,183 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { AlertCircle, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+
+interface ReportCommentModalProps {
+  isOpen: boolean
+  onClose: () => void
+  comentarioId: string
+  onSuccess: () => void
+}
+
+const reportOptions = [
+  { id: 'spam', label: 'Spam o contenido repetitivo', description: 'Contenido no deseado o repetitivo' },
+  { id: 'contenido_inapropiado', label: 'Contenido inapropiado', description: 'Lenguaje ofensivo o inapropiado' },
+  { id: 'informacion_falsa', label: 'Información falsa', description: 'Información incorrecta o engañosa' },
+  { id: 'otro', label: 'Otro motivo', description: 'Otra razón no listada anteriormente' },
+] as const
+
+export function ReportCommentModal({ 
+  isOpen, 
+  onClose, 
+  comentarioId, 
+  onSuccess 
+}: ReportCommentModalProps) {
+  const [selectedMotivos, setSelectedMotivos] = useState<string[]>([])
+  const [observaciones, setObservaciones] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleMotivoChange = (motivoId: string, checked: boolean) => {
+    if (checked) {
+      setSelectedMotivos(prev => [...prev, motivoId])
+    } else {
+      setSelectedMotivos(prev => prev.filter(id => id !== motivoId))
+    }
+  }
+
+  const handleSubmit = async () => {
+    if (selectedMotivos.length === 0) {
+      toast.error('Debes seleccionar al menos un motivo')
+      return
+    }
+
+    try {
+      setIsSubmitting(true)
+
+      const response = await fetch(`/api/comentarios/${comentarioId}/reportes`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          motivos: selectedMotivos,
+          observaciones: observaciones.trim() || undefined,
+        }),
+      })
+
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(error.error || 'Error al enviar reporte')
+      }
+
+      // Reset form
+      setSelectedMotivos([])
+      setObservaciones('')
+      
+      onSuccess()
+    } catch (error) {
+      console.error('Error reporting comment:', error)
+      toast.error(error instanceof Error ? error.message : 'Error al enviar reporte')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleClose = () => {
+    if (!isSubmitting) {
+      setSelectedMotivos([])
+      setObservaciones('')
+      onClose()
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertCircle className="h-5 w-5 text-red-600" />
+            Reportar comentario
+          </DialogTitle>
+          <DialogDescription>
+            Ayúdanos a mantener una comunidad segura. Selecciona el motivo del reporte.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Report reasons */}
+          <div className="space-y-3">
+            <Label className="text-sm font-medium">
+              Motivo del reporte <span className="text-red-500">*</span>
+            </Label>
+            {reportOptions.map((option) => (
+              <div key={option.id} className="flex items-start space-x-2">
+                <Checkbox
+                  id={option.id}
+                  checked={selectedMotivos.includes(option.id)}
+                  onCheckedChange={(checked) => 
+                    handleMotivoChange(option.id, checked as boolean)
+                  }
+                  disabled={isSubmitting}
+                />
+                <div className="grid gap-1.5 leading-none">
+                  <Label
+                    htmlFor={option.id}
+                    className="text-sm font-normal leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                  >
+                    {option.label}
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    {option.description}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Additional observations */}
+          <div className="space-y-2">
+            <Label htmlFor="observaciones" className="text-sm font-medium">
+              Observaciones adicionales (opcional)
+            </Label>
+            <Textarea
+              id="observaciones"
+              placeholder="Proporciona más detalles sobre el problema..."
+              value={observaciones}
+              onChange={(e) => setObservaciones(e.target.value)}
+              maxLength={288}
+              rows={3}
+              disabled={isSubmitting}
+            />
+            <div className="flex justify-between text-xs text-muted-foreground">
+              <span>Máximo 288 caracteres</span>
+              <span>{observaciones.length}/288</span>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter className="flex-col-reverse sm:flex-row gap-2">
+          <Button
+            variant="outline"
+            onClick={handleClose}
+            disabled={isSubmitting}
+            className="w-full sm:w-auto"
+          >
+            Cancelar
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={isSubmitting || selectedMotivos.length === 0}
+            className="w-full sm:w-auto"
+          >
+            {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {isSubmitting ? 'Enviando...' : 'Enviar reporte'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/station/StationComments.tsx
+++ b/components/station/StationComments.tsx
@@ -143,9 +143,13 @@ export function StationComments({ estacionId }: StationCommentsProps) {
     }
   }
 
-  const formatTimeAgo = (date: Date) => {
+  // Normaliza entradas tipo Date o string ISO a un objeto Date
+  const toDate = (d: Date | string) => (d instanceof Date ? d : new Date(d))
+
+  const formatTimeAgo = (date: Date | string) => {
     const now = new Date()
-    const diffInHours = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60))
+    const d = toDate(date)
+    const diffInHours = Math.floor((now.getTime() - d.getTime()) / (1000 * 60 * 60))
     
     if (diffInHours < 1) return 'Hace menos de 1 hora'
     if (diffInHours < 24) return `Hace ${diffInHours} hora${diffInHours > 1 ? 's' : ''}`
@@ -153,7 +157,7 @@ export function StationComments({ estacionId }: StationCommentsProps) {
     const diffInDays = Math.floor(diffInHours / 24)
     if (diffInDays < 7) return `Hace ${diffInDays} día${diffInDays > 1 ? 's' : ''}`
     
-    return new Date(date).toLocaleDateString('es-AR')
+    return d.toLocaleDateString('es-AR')
   }
 
   const userComment = comentarios.find(c => c.usuarioId === session?.user?.id)
@@ -270,7 +274,7 @@ export function StationComments({ estacionId }: StationCommentsProps) {
                     <span className="text-xs text-muted-foreground">
                       {formatTimeAgo(comentario.fechaCreacion)}
                     </span>
-                    {comentario.fechaActualizacion.getTime() !== comentario.fechaCreacion.getTime() && (
+                    {toDate(comentario.fechaActualizacion).getTime() !== toDate(comentario.fechaCreacion).getTime() && (
                       <span className="text-xs text-muted-foreground">(editado)</span>
                     )}
                   </div>

--- a/components/station/StationComments.tsx
+++ b/components/station/StationComments.tsx
@@ -210,12 +210,12 @@ export function StationComments({ estacionId }: StationCommentsProps) {
                 placeholder="Escribe tu comentario sobre esta estación..."
                 value={nuevoComentario}
                 onChange={(e) => setNuevoComentario(e.target.value)}
-                maxLength={500}
+                maxLength={144}
                 rows={3}
               />
               <div className="flex items-center justify-between">
                 <div className="text-xs text-muted-foreground">
-                  {nuevoComentario.length}/500 caracteres
+                  {nuevoComentario.length}/144 caracteres
                 </div>
                 <div className="flex gap-2">
                   <Button
@@ -265,7 +265,7 @@ export function StationComments({ estacionId }: StationCommentsProps) {
                 image={comentario.usuario.image || undefined}
                 size="md"
               />
-              <div className="flex-1">
+              <div className="flex-1 min-w-0">
                 <div className="flex items-center justify-between mb-1">
                   <div className="flex items-center gap-2">
                     <span className="font-medium text-sm">
@@ -309,12 +309,12 @@ export function StationComments({ estacionId }: StationCommentsProps) {
                     <Textarea
                       value={editingText}
                       onChange={(e) => setEditingText(e.target.value)}
-                      maxLength={500}
+                      maxLength={144}
                       rows={3}
                     />
                     <div className="flex items-center justify-between">
                       <div className="text-xs text-muted-foreground">
-                        {editingText.length}/500 caracteres
+                        {editingText.length}/144 caracteres
                       </div>
                       <div className="flex gap-2">
                         <Button
@@ -340,7 +340,7 @@ export function StationComments({ estacionId }: StationCommentsProps) {
                     </div>
                   </div>
                 ) : (
-                  <p className="text-sm text-foreground whitespace-pre-wrap">
+                  <p className="text-sm text-foreground whitespace-pre-wrap break-words break-all">
                     {comentario.comentario}
                   </p>
                 )}

--- a/components/station/StationComments.tsx
+++ b/components/station/StationComments.tsx
@@ -1,0 +1,362 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Card } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { MessageSquare, Edit2, Trash2, Save, X } from 'lucide-react'
+import { UserAvatar } from '@/components/ui/UserAvatar'
+import { authClient } from '@/lib/authClient'
+import { toast } from 'sonner'
+import { Comentario } from '@/drizzle/schema'
+
+interface ComentarioWithUser extends Comentario {
+  usuario: {
+    id: string
+    name: string | null
+    image: string | null
+  }
+}
+
+interface StationCommentsProps {
+  estacionId: string
+}
+
+export function StationComments({ estacionId }: StationCommentsProps) {
+  const [comentarios, setComentarios] = useState<ComentarioWithUser[]>([])
+  const [loading, setLoading] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const [editing, setEditing] = useState<string | null>(null)
+  const [showForm, setShowForm] = useState(false)
+  const [nuevoComentario, setNuevoComentario] = useState('')
+  const [editingText, setEditingText] = useState('')
+  const { data: session } = authClient.useSession()
+
+  const fetchComentarios = async () => {
+    try {
+      const response = await fetch(`/api/comentarios?estacionId=${estacionId}`)
+      if (response.ok) {
+        const data = await response.json()
+        setComentarios(data)
+      }
+    } catch (error) {
+      console.error('Error fetching comentarios:', error)
+      toast.error('Error al cargar comentarios')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchComentarios()
+  }, [estacionId])
+
+  const handleSubmitComentario = async () => {
+    if (!session?.user) {
+      toast.error('Debes iniciar sesión para comentar')
+      return
+    }
+
+    if (!nuevoComentario.trim()) {
+      toast.error('El comentario no puede estar vacío')
+      return
+    }
+
+    try {
+      setSubmitting(true)
+      const response = await fetch('/api/comentarios', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          estacionId,
+          comentario: nuevoComentario.trim()
+        })
+      })
+
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(error.error || 'Error al enviar comentario')
+      }
+
+      setNuevoComentario('')
+      setShowForm(false)
+      toast.success('Comentario agregado correctamente')
+      await fetchComentarios()
+    } catch (error) {
+      console.error('Error submitting comentario:', error)
+      toast.error(error instanceof Error ? error.message : 'Error al enviar comentario')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleEditComentario = async (comentarioId: string) => {
+    if (!editingText.trim()) {
+      toast.error('El comentario no puede estar vacío')
+      return
+    }
+
+    try {
+      const response = await fetch(`/api/comentarios/${comentarioId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          comentario: editingText.trim()
+        })
+      })
+
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(error.error || 'Error al actualizar comentario')
+      }
+
+      setEditing(null)
+      setEditingText('')
+      toast.success('Comentario actualizado correctamente')
+      await fetchComentarios()
+    } catch (error) {
+      console.error('Error updating comentario:', error)
+      toast.error(error instanceof Error ? error.message : 'Error al actualizar comentario')
+    }
+  }
+
+  const handleDeleteComentario = async (comentarioId: string) => {
+    if (!confirm('¿Estás seguro de que quieres eliminar este comentario?')) {
+      return
+    }
+
+    try {
+      const response = await fetch(`/api/comentarios/${comentarioId}`, {
+        method: 'DELETE'
+      })
+
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(error.error || 'Error al eliminar comentario')
+      }
+
+      toast.success('Comentario eliminado correctamente')
+      await fetchComentarios()
+    } catch (error) {
+      console.error('Error deleting comentario:', error)
+      toast.error(error instanceof Error ? error.message : 'Error al eliminar comentario')
+    }
+  }
+
+  const formatTimeAgo = (date: Date) => {
+    const now = new Date()
+    const diffInHours = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60))
+    
+    if (diffInHours < 1) return 'Hace menos de 1 hora'
+    if (diffInHours < 24) return `Hace ${diffInHours} hora${diffInHours > 1 ? 's' : ''}`
+    
+    const diffInDays = Math.floor(diffInHours / 24)
+    if (diffInDays < 7) return `Hace ${diffInDays} día${diffInDays > 1 ? 's' : ''}`
+    
+    return new Date(date).toLocaleDateString('es-AR')
+  }
+
+  const userComment = comentarios.find(c => c.usuarioId === session?.user?.id)
+
+  if (loading) {
+    return (
+      <Card className="p-4 sm:p-6">
+        <div className="flex items-center justify-center py-8">
+          <div className="animate-spin h-6 w-6 border-2 border-primary border-t-transparent rounded-full" />
+        </div>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="p-4 sm:p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-semibold flex items-center gap-2">
+          <MessageSquare className="h-5 w-5 text-blue-600" />
+          Comentarios
+          {comentarios.length > 0 && (
+            <span className="text-sm text-muted-foreground">({comentarios.length})</span>
+          )}
+        </h2>
+        
+        {session?.user && !userComment && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowForm(!showForm)}
+          >
+            {showForm ? 'Cancelar' : 'Agregar Comentario'}
+          </Button>
+        )}
+      </div>
+
+      {/* Form para nuevo comentario */}
+      {showForm && session?.user && (
+        <div className="mb-6 p-4 border rounded-lg bg-muted/20">
+          <div className="flex items-start gap-3">
+            <UserAvatar
+              userId={session.user.id}
+              name={session.user.name || undefined}
+              email={session.user.email || undefined}
+              image={session.user.image || undefined}
+              size="md"
+            />
+            <div className="flex-1 space-y-2">
+              <Textarea
+                placeholder="Escribe tu comentario sobre esta estación..."
+                value={nuevoComentario}
+                onChange={(e) => setNuevoComentario(e.target.value)}
+                maxLength={500}
+                rows={3}
+              />
+              <div className="flex items-center justify-between">
+                <div className="text-xs text-muted-foreground">
+                  {nuevoComentario.length}/500 caracteres
+                </div>
+                <div className="flex gap-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      setShowForm(false)
+                      setNuevoComentario('')
+                    }}
+                  >
+                    <X className="h-4 w-4" />
+                    Cancelar
+                  </Button>
+                  <Button
+                    size="sm"
+                    onClick={handleSubmitComentario}
+                    disabled={submitting || !nuevoComentario.trim()}
+                  >
+                    {submitting ? 'Enviando...' : 'Enviar Comentario'}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Lista de comentarios */}
+      <div className="space-y-4">
+        {comentarios.length === 0 ? (
+          <div className="text-center py-8 text-muted-foreground">
+            <MessageSquare className="h-12 w-12 mx-auto mb-2 opacity-50" />
+            <p className="text-sm">Aún no hay comentarios en esta estación.</p>
+            {session?.user && (
+              <p className="text-xs mt-1">¡Sé el primero en comentar!</p>
+            )}
+          </div>
+        ) : (
+          comentarios.map((comentario) => (
+            <div
+              key={comentario.id}
+              className="flex items-start gap-3 p-3 border rounded-lg bg-background/50"
+            >
+              <UserAvatar
+                userId={comentario.usuario.id}
+                name={comentario.usuario.name || undefined}
+                image={comentario.usuario.image || undefined}
+                size="md"
+              />
+              <div className="flex-1">
+                <div className="flex items-center justify-between mb-1">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-sm">
+                      {comentario.usuario.name || 'Usuario'}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {formatTimeAgo(comentario.fechaCreacion)}
+                    </span>
+                    {comentario.fechaActualizacion.getTime() !== comentario.fechaCreacion.getTime() && (
+                      <span className="text-xs text-muted-foreground">(editado)</span>
+                    )}
+                  </div>
+                  
+                  {session?.user?.id === comentario.usuarioId && (
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          setEditing(comentario.id)
+                          setEditingText(comentario.comentario)
+                        }}
+                        className="h-6 w-6 p-0"
+                      >
+                        <Edit2 className="h-3 w-3" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleDeleteComentario(comentario.id)}
+                        className="h-6 w-6 p-0 text-destructive hover:text-destructive"
+                      >
+                        <Trash2 className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  )}
+                </div>
+                
+                {editing === comentario.id ? (
+                  <div className="space-y-2">
+                    <Textarea
+                      value={editingText}
+                      onChange={(e) => setEditingText(e.target.value)}
+                      maxLength={500}
+                      rows={3}
+                    />
+                    <div className="flex items-center justify-between">
+                      <div className="text-xs text-muted-foreground">
+                        {editingText.length}/500 caracteres
+                      </div>
+                      <div className="flex gap-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => {
+                            setEditing(null)
+                            setEditingText('')
+                          }}
+                        >
+                          <X className="h-4 w-4" />
+                          Cancelar
+                        </Button>
+                        <Button
+                          size="sm"
+                          onClick={() => handleEditComentario(comentario.id)}
+                          disabled={!editingText.trim()}
+                        >
+                          <Save className="h-4 w-4" />
+                          Guardar
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-sm text-foreground whitespace-pre-wrap">
+                    {comentario.comentario}
+                  </p>
+                )}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Mensaje para usuarios no logueados */}
+      {!session?.user && (
+        <div className="mt-4 p-3 border rounded-lg bg-muted/20 text-center">
+          <p className="text-sm text-muted-foreground">
+            <a href="/login" className="text-primary hover:underline">
+              Inicia sesión
+            </a>{' '}
+            para agregar tu comentario sobre esta estación.
+          </p>
+        </div>
+      )}
+    </Card>
+  )
+}

--- a/components/station/StationDetail.tsx
+++ b/components/station/StationDetail.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useRef, useState } from 'react'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { MapPin, Phone, ExternalLink } from 'lucide-react'
+import { MapPin, Phone, ExternalLink, Map } from 'lucide-react'
 import { StationFull } from '@/components/StationDetailClient'
 import { getCompanyLogoPath } from '@/lib/companyLogos'
+import { useRouter } from 'next/navigation'
 
 interface StationDetailProps {
   station: StationFull
@@ -39,6 +40,7 @@ export function StationDetail({ station }: StationDetailProps) {
   const mapRef = useRef<HTMLDivElement>(null)
   const leafletMapRef = useRef<LeafletMap | null>(null)
   const [mapLoaded, setMapLoaded] = useState(false)
+  const router = useRouter()
 
   // getCompanyLogoPath now imported from '@/lib/companyLogos'
 
@@ -165,6 +167,16 @@ export function StationDetail({ station }: StationDetailProps) {
     }
   }
 
+  const handleViewNearbyStations = () => {
+    // Navigate to the map centered on this station with a 5km radius
+    const searchParams = new URLSearchParams({
+      lat: station.latitud.toString(),
+      lng: station.longitud.toString(),
+      radius: '5'
+    })
+    router.push(`/buscar?${searchParams.toString()}`)
+  }
+
   if (!mapLoaded) {
     return (
       <div className="space-y-6">
@@ -217,7 +229,15 @@ export function StationDetail({ station }: StationDetailProps) {
           </div>
           
           <div className="flex flex-col sm:flex-row gap-2">
-            <Button size="sm" onClick={handleDirections} className="flex-1 sm:flex-initial">
+            <Button 
+              size="sm" 
+              onClick={handleViewNearbyStations}
+              className="flex-1 sm:flex-initial"
+            >
+              <Map className="h-4 w-4 mr-2" />
+              Ver cercanas
+            </Button>
+            <Button variant="outline" size="sm" onClick={handleDirections} className="flex-1 sm:flex-initial">
               <ExternalLink className="h-4 w-4 mr-2" />
               Direcciones
             </Button>

--- a/drizzle/migrations/20250813124530_parched_groot.sql
+++ b/drizzle/migrations/20250813124530_parched_groot.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "comentarios" (
+	"id" text PRIMARY KEY NOT NULL,
+	"usuario_id" text NOT NULL,
+	"estacion_id" text NOT NULL,
+	"comentario" text NOT NULL,
+	"fecha_creacion" timestamp DEFAULT now() NOT NULL,
+	"fecha_actualizacion" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "comentarios" ADD CONSTRAINT "comentarios_usuario_id_user_id_fk" FOREIGN KEY ("usuario_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "comentarios" ADD CONSTRAINT "comentarios_estacion_id_estaciones_id_fk" FOREIGN KEY ("estacion_id") REFERENCES "public"."estaciones"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "comentarios_usuario_estacion_idx" ON "comentarios" USING btree ("usuario_id","estacion_id");--> statement-breakpoint
+CREATE INDEX "comentarios_estacion_idx" ON "comentarios" USING btree ("estacion_id");--> statement-breakpoint
+CREATE INDEX "comentarios_fecha_creacion_idx" ON "comentarios" USING btree ("fecha_creacion");--> statement-breakpoint
+CREATE UNIQUE INDEX "comentarios_usuario_estacion_unique" ON "comentarios" USING btree ("usuario_id","estacion_id");

--- a/drizzle/migrations/20250822130602_glorious_exodus.sql
+++ b/drizzle/migrations/20250822130602_glorious_exodus.sql
@@ -1,0 +1,29 @@
+CREATE TABLE "reportes_comentarios" (
+	"id" text PRIMARY KEY NOT NULL,
+	"comentario_id" text NOT NULL,
+	"usuario_id" text NOT NULL,
+	"motivo" text NOT NULL,
+	"observaciones" text,
+	"estado" text DEFAULT 'pendiente' NOT NULL,
+	"fecha_creacion" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "votos_comentarios" (
+	"id" text PRIMARY KEY NOT NULL,
+	"comentario_id" text NOT NULL,
+	"usuario_id" text NOT NULL,
+	"fecha_creacion" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "reportes_comentarios" ADD CONSTRAINT "reportes_comentarios_comentario_id_comentarios_id_fk" FOREIGN KEY ("comentario_id") REFERENCES "public"."comentarios"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reportes_comentarios" ADD CONSTRAINT "reportes_comentarios_usuario_id_user_id_fk" FOREIGN KEY ("usuario_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "votos_comentarios" ADD CONSTRAINT "votos_comentarios_comentario_id_comentarios_id_fk" FOREIGN KEY ("comentario_id") REFERENCES "public"."comentarios"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "votos_comentarios" ADD CONSTRAINT "votos_comentarios_usuario_id_user_id_fk" FOREIGN KEY ("usuario_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "reportes_comentarios_comentario_idx" ON "reportes_comentarios" USING btree ("comentario_id");--> statement-breakpoint
+CREATE INDEX "reportes_comentarios_usuario_idx" ON "reportes_comentarios" USING btree ("usuario_id");--> statement-breakpoint
+CREATE INDEX "reportes_comentarios_estado_idx" ON "reportes_comentarios" USING btree ("estado");--> statement-breakpoint
+CREATE INDEX "reportes_comentarios_fecha_creacion_idx" ON "reportes_comentarios" USING btree ("fecha_creacion");--> statement-breakpoint
+CREATE INDEX "votos_comentarios_comentario_usuario_idx" ON "votos_comentarios" USING btree ("comentario_id","usuario_id");--> statement-breakpoint
+CREATE INDEX "votos_comentarios_comentario_idx" ON "votos_comentarios" USING btree ("comentario_id");--> statement-breakpoint
+CREATE INDEX "votos_comentarios_usuario_idx" ON "votos_comentarios" USING btree ("usuario_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "votos_comentarios_comentario_usuario_unique" ON "votos_comentarios" USING btree ("comentario_id","usuario_id");

--- a/drizzle/migrations/meta/20250813124530_snapshot.json
+++ b/drizzle/migrations/meta/20250813124530_snapshot.json
@@ -1,0 +1,1661 @@
+{
+  "id": "aee17ca2-5b40-44bb-af82-36d0fa4c6826",
+  "prevId": "18bd95e3-6c2f-4262-98d5-221fb572dfbf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.comentarios": {
+      "name": "comentarios",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "usuario_id": {
+          "name": "usuario_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estacion_id": {
+          "name": "estacion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comentario": {
+          "name": "comentario",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fecha_creacion": {
+          "name": "fecha_creacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "fecha_actualizacion": {
+          "name": "fecha_actualizacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comentarios_usuario_estacion_idx": {
+          "name": "comentarios_usuario_estacion_idx",
+          "columns": [
+            {
+              "expression": "usuario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "estacion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comentarios_estacion_idx": {
+          "name": "comentarios_estacion_idx",
+          "columns": [
+            {
+              "expression": "estacion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comentarios_fecha_creacion_idx": {
+          "name": "comentarios_fecha_creacion_idx",
+          "columns": [
+            {
+              "expression": "fecha_creacion",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comentarios_usuario_estacion_unique": {
+          "name": "comentarios_usuario_estacion_unique",
+          "columns": [
+            {
+              "expression": "usuario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "estacion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comentarios_usuario_id_user_id_fk": {
+          "name": "comentarios_usuario_id_user_id_fk",
+          "tableFrom": "comentarios",
+          "tableTo": "user",
+          "columnsFrom": [
+            "usuario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comentarios_estacion_id_estaciones_id_fk": {
+          "name": "comentarios_estacion_id_estaciones_id_fk",
+          "tableFrom": "comentarios",
+          "tableTo": "estaciones",
+          "columnsFrom": [
+            "estacion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.confirmaciones_precios": {
+      "name": "confirmaciones_precios",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "precio_id": {
+          "name": "precio_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usuario_id": {
+          "name": "usuario_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fecha_creacion": {
+          "name": "fecha_creacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "confirmaciones_precios_precio_usuario_idx": {
+          "name": "confirmaciones_precios_precio_usuario_idx",
+          "columns": [
+            {
+              "expression": "precio_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usuario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "confirmaciones_precios_usuario_idx": {
+          "name": "confirmaciones_precios_usuario_idx",
+          "columns": [
+            {
+              "expression": "usuario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "confirmaciones_precios_precio_idx": {
+          "name": "confirmaciones_precios_precio_idx",
+          "columns": [
+            {
+              "expression": "precio_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "confirmaciones_precios_precio_id_precios_id_fk": {
+          "name": "confirmaciones_precios_precio_id_precios_id_fk",
+          "tableFrom": "confirmaciones_precios",
+          "tableTo": "precios",
+          "columnsFrom": [
+            "precio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "confirmaciones_precios_usuario_id_user_id_fk": {
+          "name": "confirmaciones_precios_usuario_id_user_id_fk",
+          "tableFrom": "confirmaciones_precios",
+          "tableTo": "user",
+          "columnsFrom": [
+            "usuario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.estaciones": {
+      "name": "estaciones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "idempresa": {
+          "name": "idempresa",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "empresa": {
+          "name": "empresa",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cuit": {
+          "name": "cuit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direccion": {
+          "name": "direccion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "localidad": {
+          "name": "localidad",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provincia": {
+          "name": "provincia",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitud": {
+          "name": "latitud",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitud": {
+          "name": "longitud",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geojson": {
+          "name": "geojson",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fecha_creacion": {
+          "name": "fecha_creacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "fecha_actualizacion": {
+          "name": "fecha_actualizacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "estaciones_lat_lng_idx": {
+          "name": "estaciones_lat_lng_idx",
+          "columns": [
+            {
+              "expression": "latitud",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "longitud",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "estaciones_provincia_localidad_idx": {
+          "name": "estaciones_provincia_localidad_idx",
+          "columns": [
+            {
+              "expression": "provincia",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "localidad",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "estaciones_empresa_idx": {
+          "name": "estaciones_empresa_idx",
+          "columns": [
+            {
+              "expression": "empresa",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "estaciones_cuit_idx": {
+          "name": "estaciones_cuit_idx",
+          "columns": [
+            {
+              "expression": "cuit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "estaciones_idempresa_idx": {
+          "name": "estaciones_idempresa_idx",
+          "columns": [
+            {
+              "expression": "idempresa",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "estaciones_idempresa_unique": {
+          "name": "estaciones_idempresa_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempresa"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favoritos": {
+      "name": "favoritos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "usuario_id": {
+          "name": "usuario_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estacion_id": {
+          "name": "estacion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fecha_creacion": {
+          "name": "fecha_creacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "favoritos_usuario_estacion_idx": {
+          "name": "favoritos_usuario_estacion_idx",
+          "columns": [
+            {
+              "expression": "usuario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "estacion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "favoritos_usuario_id_user_id_fk": {
+          "name": "favoritos_usuario_id_user_id_fk",
+          "tableFrom": "favoritos",
+          "tableTo": "user",
+          "columnsFrom": [
+            "usuario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favoritos_estacion_id_estaciones_id_fk": {
+          "name": "favoritos_estacion_id_estaciones_id_fk",
+          "tableFrom": "favoritos",
+          "tableTo": "estaciones",
+          "columnsFrom": [
+            "estacion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.precios": {
+      "name": "precios",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "estacion_id": {
+          "name": "estacion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tipo_combustible": {
+          "name": "tipo_combustible",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precio": {
+          "name": "precio",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "horario": {
+          "name": "horario",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fecha_vigencia": {
+          "name": "fecha_vigencia",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuente": {
+          "name": "fuente",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usuario_id": {
+          "name": "usuario_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "es_validado": {
+          "name": "es_validado",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fecha_reporte": {
+          "name": "fecha_reporte",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notas": {
+          "name": "notas",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidencia_url": {
+          "name": "evidencia_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "precios_estacion_tipo_combustible_idx": {
+          "name": "precios_estacion_tipo_combustible_idx",
+          "columns": [
+            {
+              "expression": "estacion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tipo_combustible",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "precios_fecha_vigencia_idx": {
+          "name": "precios_fecha_vigencia_idx",
+          "columns": [
+            {
+              "expression": "fecha_vigencia",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "precios_fuente_idx": {
+          "name": "precios_fuente_idx",
+          "columns": [
+            {
+              "expression": "fuente",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "precios_usuario_idx": {
+          "name": "precios_usuario_idx",
+          "columns": [
+            {
+              "expression": "usuario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "precios_validado_idx": {
+          "name": "precios_validado_idx",
+          "columns": [
+            {
+              "expression": "es_validado",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "precios_estacion_tipo_horario_fuente_unique": {
+          "name": "precios_estacion_tipo_horario_fuente_unique",
+          "columns": [
+            {
+              "expression": "estacion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tipo_combustible",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "horario",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fuente",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "precios_estacion_id_estaciones_id_fk": {
+          "name": "precios_estacion_id_estaciones_id_fk",
+          "tableFrom": "precios",
+          "tableTo": "estaciones",
+          "columnsFrom": [
+            "estacion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "precios_usuario_id_user_id_fk": {
+          "name": "precios_usuario_id_user_id_fk",
+          "tableFrom": "precios",
+          "tableTo": "user",
+          "columnsFrom": [
+            "usuario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.precios_historico": {
+      "name": "precios_historico",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "estacion_id": {
+          "name": "estacion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tipo_combustible": {
+          "name": "tipo_combustible",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precio": {
+          "name": "precio",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "horario": {
+          "name": "horario",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fecha_vigencia": {
+          "name": "fecha_vigencia",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuente": {
+          "name": "fuente",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usuario_id": {
+          "name": "usuario_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "es_validado": {
+          "name": "es_validado",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fecha_creacion": {
+          "name": "fecha_creacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "precios_historico_estacion_tipo_fecha_idx": {
+          "name": "precios_historico_estacion_tipo_fecha_idx",
+          "columns": [
+            {
+              "expression": "estacion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tipo_combustible",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fecha_vigencia",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "precios_historico_fecha_vigencia_idx": {
+          "name": "precios_historico_fecha_vigencia_idx",
+          "columns": [
+            {
+              "expression": "fecha_vigencia",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "precios_historico_estacion_id_estaciones_id_fk": {
+          "name": "precios_historico_estacion_id_estaciones_id_fk",
+          "tableFrom": "precios_historico",
+          "tableTo": "estaciones",
+          "columnsFrom": [
+            "estacion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "precios_historico_usuario_id_user_id_fk": {
+          "name": "precios_historico_usuario_id_user_id_fk",
+          "tableFrom": "precios_historico",
+          "tableTo": "user",
+          "columnsFrom": [
+            "usuario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reportes_precios": {
+      "name": "reportes_precios",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "estacion_id": {
+          "name": "estacion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usuario_id": {
+          "name": "usuario_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tipo_combustible": {
+          "name": "tipo_combustible",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precio": {
+          "name": "precio",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "horario": {
+          "name": "horario",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notas": {
+          "name": "notas",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fecha_creacion": {
+          "name": "fecha_creacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reportes_precios_usuario_idx": {
+          "name": "reportes_precios_usuario_idx",
+          "columns": [
+            {
+              "expression": "usuario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reportes_precios_estacion_idx": {
+          "name": "reportes_precios_estacion_idx",
+          "columns": [
+            {
+              "expression": "estacion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reportes_precios_fecha_creacion_idx": {
+          "name": "reportes_precios_fecha_creacion_idx",
+          "columns": [
+            {
+              "expression": "fecha_creacion",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reportes_precios_estacion_id_estaciones_id_fk": {
+          "name": "reportes_precios_estacion_id_estaciones_id_fk",
+          "tableFrom": "reportes_precios",
+          "tableTo": "estaciones",
+          "columnsFrom": [
+            "estacion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reportes_precios_usuario_id_user_id_fk": {
+          "name": "reportes_precios_usuario_id_user_id_fk",
+          "tableFrom": "reportes_precios",
+          "tableTo": "user",
+          "columnsFrom": [
+            "usuario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_u_r_ls": {
+          "name": "redirect_u_r_ls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_terms": {
+          "name": "accepted_terms",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_terms_at": {
+          "name": "accepted_terms_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms_hash": {
+          "name": "terms_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/20250822130602_snapshot.json
+++ b/drizzle/migrations/meta/20250822130602_snapshot.json
@@ -1,0 +1,1944 @@
+{
+  "id": "cbb6ff8d-cb4c-491e-9776-fa55d9f8782d",
+  "prevId": "aee17ca2-5b40-44bb-af82-36d0fa4c6826",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.comentarios": {
+      "name": "comentarios",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "usuario_id": {
+          "name": "usuario_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estacion_id": {
+          "name": "estacion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comentario": {
+          "name": "comentario",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fecha_creacion": {
+          "name": "fecha_creacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "fecha_actualizacion": {
+          "name": "fecha_actualizacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comentarios_usuario_estacion_idx": {
+          "name": "comentarios_usuario_estacion_idx",
+          "columns": [
+            {
+              "expression": "usuario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "estacion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comentarios_estacion_idx": {
+          "name": "comentarios_estacion_idx",
+          "columns": [
+            {
+              "expression": "estacion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comentarios_fecha_creacion_idx": {
+          "name": "comentarios_fecha_creacion_idx",
+          "columns": [
+            {
+              "expression": "fecha_creacion",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comentarios_usuario_estacion_unique": {
+          "name": "comentarios_usuario_estacion_unique",
+          "columns": [
+            {
+              "expression": "usuario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "estacion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comentarios_usuario_id_user_id_fk": {
+          "name": "comentarios_usuario_id_user_id_fk",
+          "tableFrom": "comentarios",
+          "tableTo": "user",
+          "columnsFrom": [
+            "usuario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comentarios_estacion_id_estaciones_id_fk": {
+          "name": "comentarios_estacion_id_estaciones_id_fk",
+          "tableFrom": "comentarios",
+          "tableTo": "estaciones",
+          "columnsFrom": [
+            "estacion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.confirmaciones_precios": {
+      "name": "confirmaciones_precios",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "precio_id": {
+          "name": "precio_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usuario_id": {
+          "name": "usuario_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fecha_creacion": {
+          "name": "fecha_creacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "confirmaciones_precios_precio_usuario_idx": {
+          "name": "confirmaciones_precios_precio_usuario_idx",
+          "columns": [
+            {
+              "expression": "precio_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usuario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "confirmaciones_precios_usuario_idx": {
+          "name": "confirmaciones_precios_usuario_idx",
+          "columns": [
+            {
+              "expression": "usuario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "confirmaciones_precios_precio_idx": {
+          "name": "confirmaciones_precios_precio_idx",
+          "columns": [
+            {
+              "expression": "precio_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "confirmaciones_precios_precio_id_precios_id_fk": {
+          "name": "confirmaciones_precios_precio_id_precios_id_fk",
+          "tableFrom": "confirmaciones_precios",
+          "tableTo": "precios",
+          "columnsFrom": [
+            "precio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "confirmaciones_precios_usuario_id_user_id_fk": {
+          "name": "confirmaciones_precios_usuario_id_user_id_fk",
+          "tableFrom": "confirmaciones_precios",
+          "tableTo": "user",
+          "columnsFrom": [
+            "usuario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.estaciones": {
+      "name": "estaciones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "idempresa": {
+          "name": "idempresa",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "empresa": {
+          "name": "empresa",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cuit": {
+          "name": "cuit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direccion": {
+          "name": "direccion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "localidad": {
+          "name": "localidad",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provincia": {
+          "name": "provincia",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitud": {
+          "name": "latitud",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitud": {
+          "name": "longitud",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geojson": {
+          "name": "geojson",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fecha_creacion": {
+          "name": "fecha_creacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "fecha_actualizacion": {
+          "name": "fecha_actualizacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "estaciones_lat_lng_idx": {
+          "name": "estaciones_lat_lng_idx",
+          "columns": [
+            {
+              "expression": "latitud",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "longitud",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "estaciones_provincia_localidad_idx": {
+          "name": "estaciones_provincia_localidad_idx",
+          "columns": [
+            {
+              "expression": "provincia",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "localidad",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "estaciones_empresa_idx": {
+          "name": "estaciones_empresa_idx",
+          "columns": [
+            {
+              "expression": "empresa",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "estaciones_cuit_idx": {
+          "name": "estaciones_cuit_idx",
+          "columns": [
+            {
+              "expression": "cuit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "estaciones_idempresa_idx": {
+          "name": "estaciones_idempresa_idx",
+          "columns": [
+            {
+              "expression": "idempresa",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "estaciones_idempresa_unique": {
+          "name": "estaciones_idempresa_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempresa"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favoritos": {
+      "name": "favoritos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "usuario_id": {
+          "name": "usuario_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estacion_id": {
+          "name": "estacion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fecha_creacion": {
+          "name": "fecha_creacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "favoritos_usuario_estacion_idx": {
+          "name": "favoritos_usuario_estacion_idx",
+          "columns": [
+            {
+              "expression": "usuario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "estacion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "favoritos_usuario_id_user_id_fk": {
+          "name": "favoritos_usuario_id_user_id_fk",
+          "tableFrom": "favoritos",
+          "tableTo": "user",
+          "columnsFrom": [
+            "usuario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favoritos_estacion_id_estaciones_id_fk": {
+          "name": "favoritos_estacion_id_estaciones_id_fk",
+          "tableFrom": "favoritos",
+          "tableTo": "estaciones",
+          "columnsFrom": [
+            "estacion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.precios": {
+      "name": "precios",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "estacion_id": {
+          "name": "estacion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tipo_combustible": {
+          "name": "tipo_combustible",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precio": {
+          "name": "precio",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "horario": {
+          "name": "horario",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fecha_vigencia": {
+          "name": "fecha_vigencia",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuente": {
+          "name": "fuente",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usuario_id": {
+          "name": "usuario_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "es_validado": {
+          "name": "es_validado",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fecha_reporte": {
+          "name": "fecha_reporte",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notas": {
+          "name": "notas",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidencia_url": {
+          "name": "evidencia_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "precios_estacion_tipo_combustible_idx": {
+          "name": "precios_estacion_tipo_combustible_idx",
+          "columns": [
+            {
+              "expression": "estacion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tipo_combustible",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "precios_fecha_vigencia_idx": {
+          "name": "precios_fecha_vigencia_idx",
+          "columns": [
+            {
+              "expression": "fecha_vigencia",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "precios_fuente_idx": {
+          "name": "precios_fuente_idx",
+          "columns": [
+            {
+              "expression": "fuente",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "precios_usuario_idx": {
+          "name": "precios_usuario_idx",
+          "columns": [
+            {
+              "expression": "usuario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "precios_validado_idx": {
+          "name": "precios_validado_idx",
+          "columns": [
+            {
+              "expression": "es_validado",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "precios_estacion_tipo_horario_fuente_unique": {
+          "name": "precios_estacion_tipo_horario_fuente_unique",
+          "columns": [
+            {
+              "expression": "estacion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tipo_combustible",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "horario",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fuente",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "precios_estacion_id_estaciones_id_fk": {
+          "name": "precios_estacion_id_estaciones_id_fk",
+          "tableFrom": "precios",
+          "tableTo": "estaciones",
+          "columnsFrom": [
+            "estacion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "precios_usuario_id_user_id_fk": {
+          "name": "precios_usuario_id_user_id_fk",
+          "tableFrom": "precios",
+          "tableTo": "user",
+          "columnsFrom": [
+            "usuario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.precios_historico": {
+      "name": "precios_historico",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "estacion_id": {
+          "name": "estacion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tipo_combustible": {
+          "name": "tipo_combustible",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precio": {
+          "name": "precio",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "horario": {
+          "name": "horario",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fecha_vigencia": {
+          "name": "fecha_vigencia",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuente": {
+          "name": "fuente",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usuario_id": {
+          "name": "usuario_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "es_validado": {
+          "name": "es_validado",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fecha_creacion": {
+          "name": "fecha_creacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "precios_historico_estacion_tipo_fecha_idx": {
+          "name": "precios_historico_estacion_tipo_fecha_idx",
+          "columns": [
+            {
+              "expression": "estacion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tipo_combustible",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fecha_vigencia",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "precios_historico_fecha_vigencia_idx": {
+          "name": "precios_historico_fecha_vigencia_idx",
+          "columns": [
+            {
+              "expression": "fecha_vigencia",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "precios_historico_estacion_id_estaciones_id_fk": {
+          "name": "precios_historico_estacion_id_estaciones_id_fk",
+          "tableFrom": "precios_historico",
+          "tableTo": "estaciones",
+          "columnsFrom": [
+            "estacion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "precios_historico_usuario_id_user_id_fk": {
+          "name": "precios_historico_usuario_id_user_id_fk",
+          "tableFrom": "precios_historico",
+          "tableTo": "user",
+          "columnsFrom": [
+            "usuario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reportes_comentarios": {
+      "name": "reportes_comentarios",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "comentario_id": {
+          "name": "comentario_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usuario_id": {
+          "name": "usuario_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "motivo": {
+          "name": "motivo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observaciones": {
+          "name": "observaciones",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estado": {
+          "name": "estado",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pendiente'"
+        },
+        "fecha_creacion": {
+          "name": "fecha_creacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reportes_comentarios_comentario_idx": {
+          "name": "reportes_comentarios_comentario_idx",
+          "columns": [
+            {
+              "expression": "comentario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reportes_comentarios_usuario_idx": {
+          "name": "reportes_comentarios_usuario_idx",
+          "columns": [
+            {
+              "expression": "usuario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reportes_comentarios_estado_idx": {
+          "name": "reportes_comentarios_estado_idx",
+          "columns": [
+            {
+              "expression": "estado",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reportes_comentarios_fecha_creacion_idx": {
+          "name": "reportes_comentarios_fecha_creacion_idx",
+          "columns": [
+            {
+              "expression": "fecha_creacion",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reportes_comentarios_comentario_id_comentarios_id_fk": {
+          "name": "reportes_comentarios_comentario_id_comentarios_id_fk",
+          "tableFrom": "reportes_comentarios",
+          "tableTo": "comentarios",
+          "columnsFrom": [
+            "comentario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reportes_comentarios_usuario_id_user_id_fk": {
+          "name": "reportes_comentarios_usuario_id_user_id_fk",
+          "tableFrom": "reportes_comentarios",
+          "tableTo": "user",
+          "columnsFrom": [
+            "usuario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reportes_precios": {
+      "name": "reportes_precios",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "estacion_id": {
+          "name": "estacion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usuario_id": {
+          "name": "usuario_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tipo_combustible": {
+          "name": "tipo_combustible",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precio": {
+          "name": "precio",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "horario": {
+          "name": "horario",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notas": {
+          "name": "notas",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fecha_creacion": {
+          "name": "fecha_creacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reportes_precios_usuario_idx": {
+          "name": "reportes_precios_usuario_idx",
+          "columns": [
+            {
+              "expression": "usuario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reportes_precios_estacion_idx": {
+          "name": "reportes_precios_estacion_idx",
+          "columns": [
+            {
+              "expression": "estacion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reportes_precios_fecha_creacion_idx": {
+          "name": "reportes_precios_fecha_creacion_idx",
+          "columns": [
+            {
+              "expression": "fecha_creacion",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reportes_precios_estacion_id_estaciones_id_fk": {
+          "name": "reportes_precios_estacion_id_estaciones_id_fk",
+          "tableFrom": "reportes_precios",
+          "tableTo": "estaciones",
+          "columnsFrom": [
+            "estacion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reportes_precios_usuario_id_user_id_fk": {
+          "name": "reportes_precios_usuario_id_user_id_fk",
+          "tableFrom": "reportes_precios",
+          "tableTo": "user",
+          "columnsFrom": [
+            "usuario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votos_comentarios": {
+      "name": "votos_comentarios",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "comentario_id": {
+          "name": "comentario_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usuario_id": {
+          "name": "usuario_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fecha_creacion": {
+          "name": "fecha_creacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "votos_comentarios_comentario_usuario_idx": {
+          "name": "votos_comentarios_comentario_usuario_idx",
+          "columns": [
+            {
+              "expression": "comentario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usuario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votos_comentarios_comentario_idx": {
+          "name": "votos_comentarios_comentario_idx",
+          "columns": [
+            {
+              "expression": "comentario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votos_comentarios_usuario_idx": {
+          "name": "votos_comentarios_usuario_idx",
+          "columns": [
+            {
+              "expression": "usuario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votos_comentarios_comentario_usuario_unique": {
+          "name": "votos_comentarios_comentario_usuario_unique",
+          "columns": [
+            {
+              "expression": "comentario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usuario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votos_comentarios_comentario_id_comentarios_id_fk": {
+          "name": "votos_comentarios_comentario_id_comentarios_id_fk",
+          "tableFrom": "votos_comentarios",
+          "tableTo": "comentarios",
+          "columnsFrom": [
+            "comentario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votos_comentarios_usuario_id_user_id_fk": {
+          "name": "votos_comentarios_usuario_id_user_id_fk",
+          "tableFrom": "votos_comentarios",
+          "tableTo": "user",
+          "columnsFrom": [
+            "usuario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_u_r_ls": {
+          "name": "redirect_u_r_ls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_terms": {
+          "name": "accepted_terms",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_terms_at": {
+          "name": "accepted_terms_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms_hash": {
+          "name": "terms_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1755089130046,
       "tag": "20250813124530_parched_groot",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1755867962373,
+      "tag": "20250822130602_glorious_exodus",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1754928955761,
       "tag": "20250811161555_useful_karma",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1755089130046,
+      "tag": "20250813124530_parched_groot",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -35,6 +35,12 @@ export const env = createEnv({
       .default("cmd7ideu22tzlzg0jlw2hb99b")
       .describe("Custom report price template ID for Loops.js"),
 
+    LOOPS_REPORT_COMMENT_TEMPLATE_ID: z
+      .string()
+      .optional()
+      .default("cmd7ideu22tzlzg0jlw2hb99b")
+      .describe("Custom report comment template ID for Loops.js"),
+
     LOOPS_WELCOME_TEMPLATE_ID: z
       .string()
       .optional()
@@ -133,6 +139,7 @@ export const env = createEnv({
     LOOPS_API_KEY: process.env.LOOPS_API_KEY,
     LOOPS_EMAIL_VERIFICATION_TEMPLATE_ID: process.env.LOOPS_EMAIL_VERIFICATION_TEMPLATE_ID,
     LOOPS_REPORT_PRICE_TEMPLATE_ID: process.env.LOOPS_REPORT_PRICE_TEMPLATE_ID,
+    LOOPS_REPORT_COMMENT_TEMPLATE_ID: process.env.LOOPS_REPORT_COMMENT_TEMPLATE_ID,
     LOOPS_WELCOME_TEMPLATE_ID: process.env.LOOPS_WELCOME_TEMPLATE_ID,
     LOOPS_CONTACT_TEMPLATE_ID: process.env.LOOPS_CONTACT_TEMPLATE_ID,
     LOOPS_NEWS_TEMPLATE_ID: process.env.LOOPS_NEWS_TEMPLATE_ID,

--- a/lib/generated/terms-hash.json
+++ b/lib/generated/terms-hash.json
@@ -2,6 +2,6 @@
   "hash": "d804377c8fc3474706fac8d8aa63991dd23b97592b5daebe392b7eaa98fe40fa",
   "lastUpdated": "2025-08-22",
   "version": "1.0",
-  "generatedAt": "2025-08-22T13:58:31.735Z",
+  "generatedAt": "2025-08-22T14:13:14.988Z",
   "sourceFile": "public/terminos-y-condiciones.html"
 }

--- a/lib/generated/terms-hash.json
+++ b/lib/generated/terms-hash.json
@@ -1,7 +1,7 @@
 {
   "hash": "d804377c8fc3474706fac8d8aa63991dd23b97592b5daebe392b7eaa98fe40fa",
-  "lastUpdated": "2025-08-13",
+  "lastUpdated": "2025-08-22",
   "version": "1.0",
-  "generatedAt": "2025-08-13T13:05:40.505Z",
+  "generatedAt": "2025-08-22T13:58:31.735Z",
   "sourceFile": "public/terminos-y-condiciones.html"
 }

--- a/lib/generated/terms-hash.json
+++ b/lib/generated/terms-hash.json
@@ -1,7 +1,7 @@
 {
   "hash": "d804377c8fc3474706fac8d8aa63991dd23b97592b5daebe392b7eaa98fe40fa",
-  "lastUpdated": "2025-08-12",
+  "lastUpdated": "2025-08-13",
   "version": "1.0",
-  "generatedAt": "2025-08-12T14:02:40.921Z",
+  "generatedAt": "2025-08-13T13:05:40.505Z",
   "sourceFile": "public/terminos-y-condiciones.html"
 }


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic

Adds a full comments system for stations with voting, reporting, and comment counts. Users can view and post comments on the station detail, and markers show the comment count.

- **New Features**
  - Create and edit comments (max 144 chars, auth required).
  - Vote on comments and see live vote counts; prevents duplicate votes.
  - Report comments with predefined reasons and optional notes; sends a thank-you email.
  - Station detail shows a comments section; map markers display per-station comment counts.
  - New API routes: comentarios (create/list), comentarios/[id] (update), comentarios/[id]/votos (vote), comentarios/[id]/reportes (report), estaciones/[id]/comentarios-count (count).
  - New DB tables: comentarios, votos_comentarios, reportes_comentarios (with indexes and FKs).
- **Migration**
  - Run database migrations.
  - Optionally set LOOPS_REPORT_COMMENT_TEMPLATE_ID for report emails (has a default).

<!-- End of auto-generated description by cubic. -->
